### PR TITLE
Fix compilation of KDB with cko

### DIFF
--- a/kernel/debug/kdb/kdb_io.c
+++ b/kernel/debug/kdb/kdb_io.c
@@ -703,7 +703,7 @@ kdb_printit:
 			}
 		}
 		while (c) {
-			c->write(c, kdb_buffer, retlen);
+			c->write(c, kdb_buffer, retlen, 7); /* 7 == KERN_DEBUG */
 			touch_nmi_watchdog();
 			c = c->next;
 		}
@@ -764,7 +764,7 @@ kdb_printit:
 			}
 		}
 		while (c) {
-			c->write(c, moreprompt, strlen(moreprompt));
+			c->write(c, moreprompt, strlen(moreprompt), 7); /* 7 == KERN_DEBUG */
 			touch_nmi_watchdog();
 			c = c->next;
 		}


### PR DESCRIPTION
If KDB is selected in a kernel with the cko patch applied, compilation fails with

```
kernel/debug/kdb/kdb_io.c: In function ‘vkdb_printf’:
kernel/debug/kdb/kdb_io.c:706:4: error: too few arguments to function ‘c->write’
    c->write(c, kdb_buffer, retlen);
    ^
kernel/debug/kdb/kdb_io.c:767:4: error: too few arguments to function ‘c->write’
    c->write(c, moreprompt, strlen(moreprompt));
    ^
```

The reason for this error is that cko adds another parameter indicating the output color to the console->write functions, but not to the c->write calls in KDB.
This patch adds the missing parameter to those calls, currently hardcoded to 7 (KERN_DEBUG).
The same patch should work for other kernel versions as well.
