### PR TITLE
fix the exfat module compilation

### DIFF
--- a/fs/exfat/exfat_super.c
+++ b/fs/exfat/exfat_super.c
@@ -1375,8 +1375,7 @@ static void *exfat_follow_link(struct dentry *dentry, struct nameidata *nd)
 #endif
 
 const struct inode_operations exfat_symlink_inode_operations = {
-	.readlink    = generic_readlink,
-	.follow_link = exfat_follow_link,
+	.readlink    = generic_readlink
 };
 
 static int exfat_file_release(struct inode *inode, struct file *filp)


### PR DESCRIPTION
gcc chokes on the line removed - builds fine with this modification and the module loads. I don't have any exfat formatted usb's at the moment so I haven't tested with a properly formatted filesystem.