### PR TITLE
Enable building binder and ashmem as modules

### DIFF
--- a/drivers/android/Kconfig
+++ b/drivers/android/Kconfig
@@ -9,7 +9,7 @@ config ANDROID
 if ANDROID
 
 config ANDROID_BINDER_IPC
-	bool "Android Binder IPC Driver"
+	tristate "Android Binder IPC Driver"
 	depends on MMU
 	default n
 	help

--- a/drivers/android/Makefile
+++ b/drivers/android/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 ccflags-y += -I$(src)			# needed for trace events
 
-obj-$(CONFIG_ANDROID_BINDERFS)		+= binderfs.o
-obj-$(CONFIG_ANDROID_BINDER_IPC)	+= binder.o binder_alloc.o
-obj-$(CONFIG_ANDROID_BINDER_IPC_SELFTEST) += binder_alloc_selftest.o
+obj-$(CONFIG_ANDROID_BINDER_IPC)	+= binder_linux.o
+binder_linux-y := binder.o binder_alloc.o
+binder_linux-$(CONFIG_ANDROID_BINDERFS)	+= binderfs.o
+binder_linux-$(CONFIG_ANDROID_BINDER_IPC_SELFTEST) += binder_alloc_selftest.o

--- a/drivers/android/binder_alloc.c
+++ b/drivers/android/binder_alloc.c
@@ -38,7 +38,7 @@ enum {
 };
 static uint32_t binder_alloc_debug_mask = BINDER_DEBUG_USER_ERROR;
 
-module_param_named(debug_mask, binder_alloc_debug_mask,
+module_param_named(alloc_debug_mask, binder_alloc_debug_mask,
 		   uint, 0644);
 
 #define binder_alloc_debug(mask, x...) \

--- a/drivers/staging/android/Kconfig
+++ b/drivers/staging/android/Kconfig
@@ -4,7 +4,7 @@ menu "Android"
 if ANDROID
 
 config ASHMEM
-	bool "Enable the Anonymous Shared Memory Subsystem"
+	tristate "Enable the Anonymous Shared Memory Subsystem"
 	depends on SHMEM
 	help
 	  The ashmem subsystem is a new shared memory allocator, similar to

--- a/drivers/staging/android/Makefile
+++ b/drivers/staging/android/Makefile
@@ -3,4 +3,5 @@ ccflags-y += -I$(src)			# needed for trace events
 
 obj-y					+= ion/
 
-obj-$(CONFIG_ASHMEM)			+= ashmem.o
+obj-$(CONFIG_ASHMEM)			+= ashmem_linux.o
+ashmem_linux-y				+= ashmem.o

--- a/drivers/staging/android/ashmem.c
+++ b/drivers/staging/android/ashmem.c
@@ -24,6 +24,7 @@
 #include <linux/bitops.h>
 #include <linux/mutex.h>
 #include <linux/shmem_fs.h>
+#include <linux/module.h>
 #include "ashmem.h"
 
 #define ASHMEM_NAME_PREFIX "dev/ashmem/"
@@ -965,3 +966,5 @@ out:
 	return ret;
 }
 device_initcall(ashmem_init);
+
+MODULE_LICENSE("GPL v2");

--- a/fs/file.c
+++ b/fs/file.c
@@ -676,6 +676,7 @@ out_unlock:
 	*res = NULL;
 	return -ENOENT;
 }
+EXPORT_SYMBOL(__close_fd_get_file);
 
 void do_close_on_exec(struct files_struct *files)
 {

--- a/kernel/fork.c
+++ b/kernel/fork.c
@@ -1135,6 +1135,7 @@ void mmput_async(struct mm_struct *mm)
 		schedule_work(&mm->async_put_work);
 	}
 }
+EXPORT_SYMBOL_GPL(mmput_async);
 #endif
 
 /**

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -4803,6 +4803,7 @@ int can_nice(const struct task_struct *p, const int nice)
 	return (nice_rlim <= task_rlimit(p, RLIMIT_NICE) ||
 		capable(CAP_SYS_NICE));
 }
+EXPORT_SYMBOL_GPL(can_nice);
 
 #ifdef __ARCH_WANT_SYS_NICE
 

--- a/kernel/task_work.c
+++ b/kernel/task_work.c
@@ -58,6 +58,7 @@ task_work_add(struct task_struct *task, struct callback_head *work, int notify)
 
 	return 0;
 }
+EXPORT_SYMBOL(task_work_add);
 
 /**
  * task_work_cancel - cancel a pending work added by task_work_add()

--- a/mm/memory.c
+++ b/mm/memory.c
@@ -1368,6 +1368,7 @@ void zap_page_range(struct vm_area_struct *vma, unsigned long start,
 	mmu_notifier_invalidate_range_end(&range);
 	tlb_finish_mmu(&tlb, start, range.end);
 }
+EXPORT_SYMBOL_GPL(zap_page_range);
 
 /**
  * zap_page_range_single - remove user pages in a given range

--- a/mm/shmem.c
+++ b/mm/shmem.c
@@ -4158,6 +4158,7 @@ int shmem_zero_setup(struct vm_area_struct *vma)
 
 	return 0;
 }
+EXPORT_SYMBOL_GPL(shmem_zero_setup);
 
 /**
  * shmem_read_mapping_page_gfp - read into page cache, using specified page allocation flags.

--- a/security/security.c
+++ b/security/security.c
@@ -725,24 +725,28 @@ int security_binder_set_context_mgr(struct task_struct *mgr)
 {
 	return call_int_hook(binder_set_context_mgr, 0, mgr);
 }
+EXPORT_SYMBOL_GPL(security_binder_set_context_mgr);
 
 int security_binder_transaction(struct task_struct *from,
 				struct task_struct *to)
 {
 	return call_int_hook(binder_transaction, 0, from, to);
 }
+EXPORT_SYMBOL_GPL(security_binder_transaction);
 
 int security_binder_transfer_binder(struct task_struct *from,
 				    struct task_struct *to)
 {
 	return call_int_hook(binder_transfer_binder, 0, from, to);
 }
+EXPORT_SYMBOL_GPL(security_binder_transfer_binder);
 
 int security_binder_transfer_file(struct task_struct *from,
 				  struct task_struct *to, struct file *file)
 {
 	return call_int_hook(binder_transfer_file, 0, from, to, file);
 }
+EXPORT_SYMBOL_GPL(security_binder_transfer_file);
 
 int security_ptrace_access_check(struct task_struct *child, unsigned int mode)
 {


### PR DESCRIPTION
These are the patches [from debian](https://salsa.debian.org/kernel-team/linux/-/blob/master/debian/patches/debian/android-enable-building-ashmem-and-binder-as-modules.patch) that allow binder and ashmem to be built as modules. They allow distribution packages to include the modules necessary for running Anbox (or just messing around with binder IPC) in linux>=5.7, without necessitating that without be built directly into the kernel, which would waste resources for users who don't need them.

Ubuntu and Debian are currently using these patches for kernels newer than 5.7.

The relevant Arch bug ticket is [here](https://bugs.archlinux.org/task/64778).