### PR TITLE
mm/vmscan.c: fix warnings from walk_pud_range()

### DIFF
--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -4938,8 +4938,7 @@ static bool get_next_interval(struct mm_walk *walk, unsigned long mask, unsigned
 		if ((next & mask) != (walk->vma->vm_start & mask))
 			return false;
 
-		if (next <= walk->vma->vm_start &&
-		    should_skip_vma(walk->vma->vm_start, walk->vma->vm_end, walk)) {
+		if (should_skip_vma(walk->vma->vm_start, walk->vma->vm_end, walk)) {
 			walk->vma = walk->vma->vm_next;
 			continue;
 		}


### PR DESCRIPTION
Correctly skip unevictable VMAs that contain special PFNs. Otherwise 
those PFNs trigger a warning in walk_pud_range(), which is harmless
but noisy, when using multigenerational LRU.