### PR TITLE
fixup! futex2: Implement requeue operation

### DIFF
--- a/arch/arm64/include/asm/unistd32.h
+++ b/arch/arm64/include/asm/unistd32.h
@@ -899,7 +899,7 @@ __SYSCALL(__NR_futex_wait, sys_futex_wait)
 __SYSCALL(__NR_futex_wake, sys_futex_wake)
 #define __NR_futex_waitv 445
 __SYSCALL(__NR_futex_waitv, compat_sys_futex_waitv)
-#define __NR_futex_waitv 446
+#define __NR_futex_requeue 446
 __SYSCALL(__NR_futex_requeue, compat_sys_futex_requeue)
 
 /*


### PR DESCRIPTION
In 270e16f72b29d04a83645b653e9fc65be51801d2 a new syscall (`futex_requeue`) was added.

Though there was a slight implementation failure in the arm64 side of things; the `#define` for the syscall was mistakenly defining the previous syscall again!

Leading to the following failure on arm64:

<details><summary>(Toggle for error log)</summary>
```
In file included from ../arch/arm64/kernel/sys32.c:127:
../arch/arm64/include/asm/unistd32.h:902: warning: "__NR_futex_waitv" redefined
  902 | #define __NR_futex_waitv 446
      | 
../arch/arm64/include/asm/unistd32.h:900: note: this is the location of the previous definition
  900 | #define __NR_futex_waitv 445
      | 
In file included from ../arch/arm64/kernel/sys32.c:134:
../arch/arm64/include/asm/unistd32.h:900: warning: "__NR_futex_waitv" redefined
  900 | #define __NR_futex_waitv 445
      | 
In file included from ../arch/arm64/kernel/sys32.c:127:
../arch/arm64/include/asm/unistd32.h:902: note: this is the location of the previous definition
  902 | #define __NR_futex_waitv 446
      | 
In file included from ../arch/arm64/kernel/sys32.c:134:
../arch/arm64/include/asm/unistd32.h:902: warning: "__NR_futex_waitv" redefined
  902 | #define __NR_futex_waitv 446
      | 
../arch/arm64/include/asm/unistd32.h:900: note: this is the location of the previous definition
  900 | #define __NR_futex_waitv 445
      | 
../arch/arm64/include/asm/unistd32.h:903:11: error: '__NR_futex_requeue' undeclared here (not in a function); did you mean 'futex_requeue'?
  903 | __SYSCALL(__NR_futex_requeue, compat_sys_futex_requeue)
      |           ^~~~~~~~~~~~~~~~~~
../arch/arm64/kernel/sys32.c:130:29: note: in definition of macro '__SYSCALL'
  130 | #define __SYSCALL(nr, sym) [nr] = __arm64_##sym,
      |                             ^~
../arch/arm64/include/asm/unistd32.h:903:11: error: array index in initializer not of integer type
  903 | __SYSCALL(__NR_futex_requeue, compat_sys_futex_requeue)
      |           ^~~~~~~~~~~~~~~~~~
../arch/arm64/kernel/sys32.c:130:29: note: in definition of macro '__SYSCALL'
  130 | #define __SYSCALL(nr, sym) [nr] = __arm64_##sym,
      |                             ^~
../arch/arm64/include/asm/unistd32.h:903:11: note: (near initialization for 'compat_sys_call_table')
  903 | __SYSCALL(__NR_futex_requeue, compat_sys_futex_requeue)
      |           ^~~~~~~~~~~~~~~~~~
../arch/arm64/kernel/sys32.c:130:29: note: in definition of macro '__SYSCALL'
  130 | #define __SYSCALL(nr, sym) [nr] = __arm64_##sym,
      |                             ^~
make[3]: *** [../scripts/Makefile.build:271: arch/arm64/kernel/sys32.o] Error 1
make[2]: *** [../scripts/Makefile.build:514: arch/arm64/kernel] Error 2
make[2]: *** Waiting for unfinished jobs....
```
</details>

As observed here:

 - https://hydra.nixos.org/build/145119200
 - https://hydra.nixos.org/build/145119200/nixlog/1 (large~ish)

I wasn't 100% positive on where to send the fixup, but seeing that previous PRs were received well I guess it'll work. Is there another preferred location for zen kernel contributions?

Anyway, as for the patch set, I see v4 fixed the problem. (Though it wasn't in the changelog from v3!!)

 - https://lore.kernel.org/patchwork/patch/1440883/

So I guess if that works too on top of 5.12; it's another valid fix.