### PR TITLE
mm: fix priority queue in multigenerational lru

### DIFF
--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -377,6 +377,8 @@ struct lrugen {
 	/* arithmetic mean weighted by geometric series 1/2, 1/4, ... */
 	unsigned long avg_total[ANON_AND_FILE][MAX_NR_TIERS];
 	unsigned long avg_refaulted[ANON_AND_FILE][MAX_NR_TIERS];
+	/* the priority queue when choosing reclaimable memcgs */
+	atomic_t priority;
 	/* whether the multigenerational lru is enabled */
 	bool enabled[ANON_AND_FILE];
 };

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -4135,7 +4135,7 @@ static int scan_pages(struct lruvec *lruvec, struct scan_control *sc, long *nr_t
 	}
 
 	success = try_inc_min_seq(lruvec, type);
-	if (memcg && !mem_cgroup_is_root(memcg) && !cgroup_reclaim(sc) && success && file)
+	if (memcg && !mem_cgroup_is_root(memcg) && !cgroup_reclaim(sc) && success && type)
 		atomic_add_unless(&lrugen->priority, -1, 0);
 
 	item = current_is_kswapd() ? PGSCAN_KSWAPD : PGSCAN_DIRECT;
@@ -4460,10 +4460,14 @@ static void lru_gen_age_node(struct pglist_data *pgdat, struct scan_control *sc)
 	memcg = mem_cgroup_iter(NULL, NULL, NULL);
 	do {
 		struct lruvec *lruvec = mem_cgroup_lruvec(memcg, pgdat);
+		struct lrugen *lrugen = &lruvec->evictable;
 
 		if (!mem_cgroup_below_min(memcg) &&
 		    (!mem_cgroup_below_low(memcg) || sc->memcg_low_reclaim))
 			try_walk_mm_list(lruvec, sc);
+
+		if (memcg && !mem_cgroup_is_root(memcg) && sc->priority != DEF_PRIORITY)
+			atomic_add_unless(&lrugen->priority, 1, DEF_PRIORITY);
 
 		cond_resched();
 	} while ((memcg = mem_cgroup_iter(NULL, memcg, NULL)));
@@ -4869,7 +4873,7 @@ static int lru_gen_seq_show(struct seq_file *m, void *v)
 		seq_printf(m, "memcg %5hu %s\n", mem_cgroup_id(memcg), (char *)m->private);
 	}
 
-	seq_printf(m, " node %5d\n", nid);
+	seq_printf(m, " node %5d %10d\n", nid, atomic_read(&lrugen->priority));
 
 	seq = full ? (max_seq < MAX_NR_GENS ? 0 : max_seq - MAX_NR_GENS + 1) :
 		     min(min_seq[0], min_seq[1]);
@@ -5094,6 +5098,8 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
 	lrugen->max_seq = MIN_NR_GENS + 1;
 	lrugen->enabled[0] = lru_gen_enabled() && lru_gen_nr_swapfiles;
 	lrugen->enabled[1] = lru_gen_enabled();
+
+	atomic_set(&lrugen->priority, DEF_PRIORITY);
 
 	for (i = 0; i <= MIN_NR_GENS + 1; i++)
 		lrugen->timestamps[i] = jiffies;


### PR DESCRIPTION
The priority queue helps select the best memcg to reclaim memory from
when there are multiple candidates. If reclaim didn't make progress
after it has tried those at the front, it increments the priority of
the rest in the queue by one. If the queue is not empty, more memcgs
will appear at the front and then reclaim will try them again.

However, this wasn't properly implemented, which causes the memory
pressure to be distributed to all memcgs in the queue. If one of them
uses a large amount of page cache, the distributed memory pressure
will slow down the rest.

Signed-off-by: Yu Zhao <yuzhao@google.com>