### PR TITLE
Fix order of remapped nvme devices

### DIFF
--- a/drivers/pci/controller/intel-nvme-remap.c
+++ b/drivers/pci/controller/intel-nvme-remap.c
@@ -310,7 +310,7 @@ static int find_remapped_devices(struct nvme_remap_dev *nrdev,
 		return -ENODEV;
 
 	cap = readq(mmio + AHCI_REMAP_CAP);
-	for (i = 0; i < AHCI_MAX_REMAP; i++) {
+	for (i = AHCI_MAX_REMAP-1; i >= 0; i--) {
 		struct resource *remapped_mem;
 
 		if ((cap & (1 << i)) == 0)


### PR DESCRIPTION
Fix order of remapped nvme devices.

On my hardware the nvme devices are being ordered the opposite way in rst mode than in ahci mode. For non initrd users this means grub cannot find the root partition when switching between ahci and rst in bios. Hoping this is a general issue and not just with my hardware (Dell Precision 7550). If there are complaints from other users (with other devices) about the ordering being wrong for them, this should be easy to revert.