### PR TITLE
mm: multigenerational lru: balance memory pressure between memcgs

### DIFF
--- a/include/linux/mmzone.h
+++ b/include/linux/mmzone.h
@@ -377,8 +377,6 @@ struct lrugen {
 	/* arithmetic mean weighted by geometric series 1/2, 1/4, ... */
 	unsigned long avg_total[ANON_AND_FILE][MAX_NR_TIERS];
 	unsigned long avg_refaulted[ANON_AND_FILE][MAX_NR_TIERS];
-	/* reclaim priority to compare across memcgs */
-	atomic_t priority;
 	/* whether the multigenerational lru is enabled */
 	bool enabled[ANON_AND_FILE];
 };

--- a/mm/vmscan.c
+++ b/mm/vmscan.c
@@ -5767,22 +5767,18 @@ static int scan_lru_gen_pages(struct lruvec *lruvec, struct scan_control *sc,
 				isolated += delta;
 			}
 
-			if (scanned >= *nr_to_scan || isolated >= SWAP_CLUSTER_MAX ||
-			    ++batch_size == MAX_BATCH_SIZE)
+			if (isolated >= SWAP_CLUSTER_MAX || ++batch_size == MAX_BATCH_SIZE)
 				break;
 		}
 
 		list_splice(&moved, head);
 		__count_zid_vm_events(PGSCAN_SKIP, zone, skipped);
 
-		if (scanned >= *nr_to_scan || isolated >= SWAP_CLUSTER_MAX ||
-		    batch_size == MAX_BATCH_SIZE)
+		if (isolated >= SWAP_CLUSTER_MAX || batch_size == MAX_BATCH_SIZE)
 			break;
 	}
 
 	success = try_inc_min_seq(lruvec, file);
-	if (memcg && !mem_cgroup_is_root(memcg) && !cgroup_reclaim(sc) && success && file)
-		atomic_add_unless(&lrugen->priority, -1, 0);
 
 	item = current_is_kswapd() ? PGSCAN_KSWAPD : PGSCAN_DIRECT;
 	if (!cgroup_reclaim(sc))
@@ -5799,7 +5795,7 @@ static int scan_lru_gen_pages(struct lruvec *lruvec, struct scan_control *sc,
 	 * may_unmap and may_writepage. The following check makes sure we won't
 	 * be stuck if we aren't making enough progress.
 	 */
-	return batch_size == MAX_BATCH_SIZE && sorted >= SWAP_CLUSTER_MAX ? 0 : -ENOENT;
+	return batch_size == MAX_BATCH_SIZE && sorted >= scanned / 2 ? 0 : -ENOENT;
 }
 
 static int get_tier_to_isolate(struct lruvec *lruvec, int file)
@@ -5985,16 +5981,12 @@ static unsigned long get_nr_to_scan(struct lruvec *lruvec, struct scan_control *
 				    int swappiness)
 {
 	int gen, file, zone;
+	int nr_gens;
 	long nr_to_scan = 0;
 	struct lrugen *lrugen = &lruvec->evictable;
+	struct mem_cgroup *memcg = lruvec_memcg(lruvec);
 	DEFINE_MAX_SEQ();
 	DEFINE_MIN_SEQ();
-
-	/* only proceed with memcgs at the front of the priority queue */
-	if (!cgroup_reclaim(sc) && atomic_read(&lrugen->priority) != DEF_PRIORITY)
-		return 0;
-
-	lru_add_drain();
 
 	for (file = !swappiness; file < ANON_AND_FILE; file++) {
 		unsigned long seq;
@@ -6007,15 +5999,29 @@ static unsigned long get_nr_to_scan(struct lruvec *lruvec, struct scan_control *
 		}
 	}
 
-	nr_to_scan = max(nr_to_scan, 0L);
-	nr_to_scan = round_up(nr_to_scan >> sc->priority, SWAP_CLUSTER_MAX);
+	if (nr_to_scan <= 0)
+		return 0;
 
-	if (max_nr_gens(max_seq, min_seq, swappiness) > MIN_NR_GENS)
+	nr_gens = max_nr_gens(max_seq, min_seq, swappiness);
+
+	if (current_is_kswapd()) {
+		/* leave the work to age_lru_gens() */
+		if (nr_gens == MIN_NR_GENS)
+			return 0;
+
+		if (nr_to_scan >= sc->nr_to_reclaim)
+			sc->force_deactivate = 0;
+	}
+
+	nr_to_scan = max(nr_to_scan >> sc->priority, (long)!mem_cgroup_online(memcg));
+	if (!nr_to_scan || nr_gens > MIN_NR_GENS)
 		return nr_to_scan;
 
-	/* kswapd uses age_lru_gens() */
-	if (current_is_kswapd())
+	/* move onto other memcgs if we haven't tried them all yet */
+	if (memcg && !sc->force_deactivate) {
+		sc->skipped_deactivate = 1;
 		return 0;
+	}
 
 	return walk_mm_list(lruvec, max_seq, sc, swappiness, NULL) ? nr_to_scan : 0;
 }
@@ -6026,6 +6032,8 @@ static void shrink_lru_gens(struct lruvec *lruvec, struct scan_control *sc)
 	unsigned long scanned = 0;
 	struct mem_cgroup *memcg = lruvec_memcg(lruvec);
 
+	lru_add_drain();
+
 	blk_start_plug(&plug);
 
 	while (true) {
@@ -6033,7 +6041,7 @@ static void shrink_lru_gens(struct lruvec *lruvec, struct scan_control *sc)
 		int swappiness = sc->may_swap ? get_swappiness(lruvec) : 0;
 
 		nr_to_scan = get_nr_to_scan(lruvec, sc, swappiness) - scanned;
-		if (nr_to_scan < (long)SWAP_CLUSTER_MAX)
+		if (nr_to_scan <= 0)
 			break;
 
 		scanned += nr_to_scan;
@@ -6104,17 +6112,21 @@ static void age_lru_gens(struct pglist_data *pgdat, struct scan_control *sc)
 
 	VM_BUG_ON(!current_is_kswapd());
 
+	if (!mem_cgroup_disabled() && !sc->force_deactivate) {
+		/* we may clear this later in get_nr_to_scan() */
+		sc->force_deactivate = 1;
+		return;
+	}
+
+	sc->force_deactivate = 0;
+
 	memcg = mem_cgroup_iter(NULL, NULL, NULL);
 	do {
 		struct lruvec *lruvec = mem_cgroup_lruvec(memcg, pgdat);
-		struct lrugen *lrugen = &lruvec->evictable;
 
 		if (!mem_cgroup_below_min(memcg) &&
 		    (!mem_cgroup_below_low(memcg) || sc->memcg_low_reclaim))
 			try_walk_mm_list(lruvec, sc);
-
-		if (memcg && !mem_cgroup_is_root(memcg) && sc->priority != DEF_PRIORITY)
-			atomic_add_unless(&lrugen->priority, 1, DEF_PRIORITY);
 
 		cond_resched();
 	} while ((memcg = mem_cgroup_iter(NULL, memcg, NULL)));
@@ -6507,7 +6519,7 @@ static int lru_gen_seq_show(struct seq_file *m, void *v)
 			   mem_cgroup_id(memcg), (char *)m->private);
 	}
 
-	seq_printf(m, " node %5d %10d\n", nid, atomic_read(&lrugen->priority));
+	seq_printf(m, " node %5d\n", nid);
 
 	seq = full ? (max_seq < MAX_NR_GENS ? 0 : max_seq - MAX_NR_GENS + 1) :
 		     min(min_seq[0], min_seq[1]);
@@ -6729,8 +6741,6 @@ void lru_gen_init_lruvec(struct lruvec *lruvec)
 	int i;
 	int gen, file, zone;
 	struct lrugen *lrugen = &lruvec->evictable;
-
-	atomic_set(&lrugen->priority, DEF_PRIORITY);
 
 	lrugen->max_seq = MIN_NR_GENS + 1;
 	lrugen->enabled[0] = lru_gen_enabled() && lru_gen_nr_swapfiles;


### PR DESCRIPTION
Properly balance memory pressure with a two-pass sweep of all memcgs.
During the first pass, we either reclaim from some memcgs or ascertain
whether none of them can be reclaimed. If it's the former, then the
second pass is not needed. Otherwise, during the second pass, we
invoke the aging so that some memcgs will become reclaimable.

Signed-off-by: Yu Zhao <yuzhao@google.com>