### PR TITLE
don't expose PML support to L1

### DIFF
--- a/arch/x86/kvm/vmx/nested.c
+++ b/arch/x86/kvm/vmx/nested.c
@@ -5894,7 +5894,8 @@ static bool nested_vmx_l0_wants_exit(struct kvm_vcpu *vcpu,
 		 * PML is emulated for an L1 VMM and should never be enabled in
 		 * vmcs02, always "handle" PML_FULL by exiting to userspace.
 		 */
-		return true;
+        /* We don't expose PML support to L1. */
+		return false;
 	case EXIT_REASON_VMFUNC:
 		/* VM functions are emulated through L2->L0 vmexits. */
 		return true;


### PR DESCRIPTION
this small change will fix issues that occur during nested virtualization where the VM will freeze for example Windows VMs that use nested virtualization will blue screen with the hypervisor error code this fixes that