### PR TITLE
ahci: Disable staggered spinup by default

### DIFF
--- a/drivers/ata/libahci.c
+++ b/drivers/ata/libahci.c
@@ -34,7 +34,7 @@
 #include "libata.h"
 
 static int ahci_skip_host_reset;
-int ahci_ignore_sss;
+int ahci_ignore_sss = 1;
 EXPORT_SYMBOL_GPL(ahci_ignore_sss);
 
 module_param_named(skip_host_reset, ahci_skip_host_reset, int, 0444);


### PR DESCRIPTION
This patch disabled the staggered spinup used for HDDs by default.

The goal is to make boot times faster on systems
with the small downside of a small spike in power consumption.

Systems with a bunch of HDDs would see considerable faster boots

This does make sense in the zen kernel as its supposed to be a kernel specialized for desktop performance, and faster boot times does fit into that description.

I wasnt sure into what branch to merge this into so i chose 6.12/main, if anything else has to be done im open to suggestions

Thank you zen team