### PR TITLE
i915 framebuffer dimensions enforcements

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -199,10 +199,10 @@ static int intelfb_create(struct drm_fb_helper *helper,
 	ifbdev->fb = NULL;
 
 	if (fb &&
-	    (sizes->fb_width > fb->base.width ||
-	     sizes->fb_height > fb->base.height)) {
+	    (sizes->fb_width != fb->base.width ||
+	     sizes->fb_height != fb->base.height)) {
 		drm_dbg_kms(&dev_priv->drm,
-			    "BIOS fb too small (%dx%d), we require (%dx%d),"
+			    "BIOS fb not valid (%dx%d), we require (%dx%d),"
 			    " releasing it\n",
 			    fb->base.width, fb->base.height,
 			    sizes->fb_width, sizes->fb_height);


### PR DESCRIPTION
Purpose: The original logic released the framebuffer only if the new dimensions were larger than the current ones, potentially allowing minor size mismatches to go unchecked. The updated logic enforces that any size mismatch, whether larger or smaller, results in the framebuffer being released and replaced.

Validation: The updated condition ensures a stricter validation by requiring the exact dimensions to match, which can help avoid graphical issues or rendering problems caused by mismatched framebuffer sizes.